### PR TITLE
Fix HTML markup on staff page

### DIFF
--- a/staff.html
+++ b/staff.html
@@ -86,18 +86,18 @@
             </svg>
             <span class="text-base font-medium">Đang tải...</span>
           </span>
-        </template></span>
+        </template>
       </div>
   </header>
 
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
-    <div x-show="currentView ==</div>= 'list'" x-cloak>
+    <div x-show="currentView === 'list'" x-cloak>
       <nav class="w-full mb-8" x-show="!loading.initialSetup && categories.length > 0">
         <div class="max-w-5xl mx-auto px-4 py-3">
           <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:justify-center sm:gap-4">
             <!-- Nút 'Tất cả' -->
-            <button @click="selectCategory('')" :class="selectedCategoryId === '' 
+            <button @click="selectCategory('')" :class="selectedCategoryId === ''
       ? 'bg-blue-600 text-white' 
       : 'bg-white text-gray-700 hover:bg-blue-100 hover:text-blue-700'"
               class="w-full sm:w-auto text-center px-4 py-3 rounded-lg text-base font-semibold transition-all duration-200 ease-in-out">


### PR DESCRIPTION
## Summary
- remove stray closing tag on staff page
- fix `x-show` condition for staff view

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894eed7c2d4832ba12d2b302d228b90